### PR TITLE
Fix multiselect dropdown min height

### DIFF
--- a/resources/js/components/MultiselectFilter.vue
+++ b/resources/js/components/MultiselectFilter.vue
@@ -353,6 +353,7 @@ $red500: #ef4444;
   .multiselect__content-wrapper {
     border-color: $slate300;
     transition: none;
+    min-height: 100px;
 
     .multiselect__content {
       overflow: hidden;


### PR DESCRIPTION
Fixes #22 #23 

This fix works for me (tried it in the browser directly)

Note: It should be backported to v4 also.